### PR TITLE
Update const.py to expose add'l movement variables

### DIFF
--- a/src/pyowletapi/const.py
+++ b/src/pyowletapi/const.py
@@ -19,7 +19,6 @@ VITALS = {
     # Firmware update status - "ota" int
     # Sock readings flag - "srf" int
     # Soft brick status - "sb" int
-    # Movement bucket - "mvb" int
     # Wellness alert - "onm" int
     # Hardware version - "hw" String
     # Monitoring start time - "mst" int
@@ -38,8 +37,16 @@ VITALS = {
         "charging": "chg",
         "base_station_on": "bso",
     },
-    int: {"sock_connection": "sc", "skin_temperature": "st", "sleep_state": "ss"},
-    "other": {"last_updated": "data_updated_at"},
+    int: {
+        "sock_connection": "sc", 
+        "skin_temperature": "st", 
+        "sleep_state": "ss", 
+        "movement": "mv", 
+        "movement_bucket": "mvb"
+    },
+    "other": {
+        "last_updated": "data_updated_at"
+    },
 }
 
 REGION_INFO = {


### PR DESCRIPTION
I've added movement and movement_bucket to the list of variables exposed by default by the API.  This will allow for mimicking of the Owlet app by using the movement value to indicate the amount of movement.  I left the boolean value 'moving' so it does not break previous implementations, but I think if you wanted to convert the movement integer to a boolean, it should be done on the application side and not the api.

Also, wondering if the api should not expose all of the variables it has available to it and choose what you ignore in the application code as well.  This would reduce requests for implementation of other variables by other apps and leave your pyowletapi module as the default module for most applications that need to access owlet data.